### PR TITLE
Adam's addition to cov_adj

### DIFF
--- a/R/cov_adj.R
+++ b/R/cov_adj.R
@@ -22,6 +22,23 @@ cov_adj <- function(model, newdata = NULL, design =  NULL) {
        })
   }
 
+  if (is.null(design)) { ### I moved this up here
+    design <- .get_design(NULL_on_error = TRUE)
+  }
+
+  if(!is.null(design)) ### added this
+    ##if(design@type=='RD') ## I think we want to set Z=0 for all design types, right?
+  {
+    trt_name <- var_names(design,'t')
+    if(trt_name %in% names(newdata))
+      if(is.numeric(newdata[[trt_name]])){
+        newdata[[trt_name]] <- 0 ## are the scenarios where 0 is not the control value?
+      } else if(is.logical(newdata[[trt_name]])){
+        newdata[[trt_name]] <- FALSE
+      } else warning(paste("The treatment variable is in the covariance adjustment model,",
+                           "and is neither logical or numeric; for now, partial residuals",
+                           "only implemented for logical or numeric treatments"))
+  }
 
   ca_and_grad <- .get_ca_and_prediction_gradient(model, newdata)
   psl <- new("PreSandwichLayer",
@@ -29,9 +46,6 @@ cov_adj <- function(model, newdata = NULL, design =  NULL) {
              fitted_covariance_model = model,
              prediction_gradient = ca_and_grad$prediction_gradient)
 
-  if (is.null(design)) {
-    design <- .get_design(NULL_on_error = TRUE)
-  }
 
   if (is.null(design)) {
     return(psl)


### PR DESCRIPTION
In 7/14 meeting we realized that the covariance adjustment model sometimes includes treatment indicators, but for covariance adjustment we want to offset by partial residuals, without the contribution from the treatment indicator.

I added code to do that in `cov_adj` for numeric and logical treatments. 
Along the way a couple questions occurred to me, denoted in code comments:

- Do we only want to do this for RD designs, or all designs? I assumed the latter, but there's a commented line of code that limits this to RD
- Are there scenarios in which the treatment is numeric but the control value is something other than 0?