### PR TITLE
Update scaling constants in the spec doc to reflect the codebase

### DIFF
--- a/vignettes/not-for-cran/estfun_DA.tex
+++ b/vignettes/not-for-cran/estfun_DA.tex
@@ -416,14 +416,14 @@ defining $\tilde{k}$ by 1 random matrices
     \beta), 
 \end{equation}
 we have in the model-based formulation 
-\begin{multline*}
+\begin{multline}
   \operatorname{Cov}\left(n^{-1}\sum_{i=1}^{n} \psi_\text{DA}(\vec{Z}_{i}; \tau_{(n)},\alpha_{(n)},
     \beta_{(n)})\right) = \\
   n^{-1}M_{22} -
                                  n_{\mathcal{C}}^{-1}[M_{21}A_{11}^{-t}A_{21}^t
                                  + A_{21}A_{11}^{-1}M_{12}] +
-                                 \frac{n}{n_{\mathcal{C}}^{2}}A_{21}A_{11}^{-1}M_{11}A_{11}^{-t}A_{21}^{t},
-                               \end{multline*}
+                                 \frac{n}{n_{\mathcal{C}}^{2}}A_{21}A_{11}^{-1}M_{11}A_{11}^{-t}A_{21}^{t},\label{eq:12}
+                               \end{multline}
 regardless of what adjustments for
 clustering or heteroskedasticity that we might seek to apply.
 


### PR DESCRIPTION
This branch updates the spec document to reflect the way I've coded `estfun.DirectAdjusted()`, `.get_a11()`, and `.get_a21()` in [DirectAdjusted.R](R/DirectAdjusted.R) and [SandwichLayerVariance.R](R/SandwichLayerVariance.R), respectively. I've posted screenshots below that compare the changes between the original and updated documents in the section that derives these expressions. I've also updated expressions later in the document that reference the $(n/n_{\mathcal{C}})^{1/2}$ scaling constant, but I haven't added screenshots here. This includes changes to the sections of the document discussing design-based variance estimation, so @xinhew0708, in addition to taking a look over my changes here, I'm also tagging you to take a look and make sure this doesn't change the way you've written your design-based code.

## Original Spec Doc (pg. 5)
<img width="690" alt="original_estfunDA_expressiongs_page1" src="https://github.com/benbhansen-stats/propertee/assets/40576459/40444af7-0ba3-4e74-a79c-2ffdbd0be34c">

## Updated Spec Doc (pg. 5)
<img width="676" alt="new_estfunDA_expressions_page1" src="https://github.com/benbhansen-stats/propertee/assets/40576459/00a2c05a-2684-43d1-9d74-d274e1df559c">

## Original Spec Doc (pg. 6)
<img width="489" alt="original_estfunDA_expressions_page2" src="https://github.com/benbhansen-stats/propertee/assets/40576459/bc4c17db-f171-4a04-8b1d-1eb68a019add">

## Updated Spec Doc (pg. 6)
<img width="553" alt="new_estfunDA_expressions_page2" src="https://github.com/benbhansen-stats/propertee/assets/40576459/d618967b-1822-469a-a4e5-f501bb6f9948">

## Original Spec Doc (pg. 7)
<img width="710" alt="original_estfunDA_expressions_page3" src="https://github.com/benbhansen-stats/propertee/assets/40576459/32d9a940-7bd0-4c57-aaa1-ac6a8fed0cc7">

## Updated Spec Doc (pg. 7)
<img width="543" alt="new_estfunDA_expressions_page3" src="https://github.com/benbhansen-stats/propertee/assets/40576459/6ebee3c5-6834-464b-ac4e-fcc43cce84c7">
