### PR TITLE
Fix spec phi scale

### DIFF
--- a/vignettes/not-for-cran/estfun_DA.tex
+++ b/vignettes/not-for-cran/estfun_DA.tex
@@ -529,11 +529,11 @@ $\tilde{A}_{22}$ in place, $\operatorname{Cov}(\hat\tau) \approx$
                                  \frac{n_{\mathcal{Q}}^{2}}{n_{\mathcal{C}}n}A_{21}A_{11}^{-1}M_{11}A_{11}^{-t}A_{21}^{t}\}\tilde{A}_{22}^{-t} .\nonumber
   \end{align*}
  We engender corresponding estimates of $\operatorname{Cov}(\hat\tau)$ by setting \eqref{eq:22}'s
- $(c_{2}, c_{1})$ to $(1, n_{\mathcal{Q}}n_{\mathcal{C}}^{-1/2}n^{-1/2})$, that is having
+ $(c_{2}, c_{1})$ to $(1, n_{\mathcal{Q}}n_{\mathcal{C}}^{-1})$, that is having
  \texttt{estfun.DA()} return $\Psi -
  \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}\Phi
  \hat{A}_{11}^{-1}\hat{A}_{21}^{t}$, or simply $\Psi$ if $n_{\mathcal{C}}=0$, while having \texttt{bread.DA()}
- return $\tilde{A}_{22}^{-1}$.
+ return $\hat{\tilde{A}}_{22}^{-1}$.
 
 
   \subsubsection{Clustered estimation of meat matrices}
@@ -557,18 +557,19 @@ column for each cluster:
     \end{array}
   \end{equation}
   
-\subsection{Realization of goal}
+\subsection{Realization of goal} \label{sec:realization-goal}
 Leaving the clusterwise aggregation to \texttt{sandwich}, as
 appropriate, it seems that if we define
 \texttt{sandwich::estfun.DirectAdjusted()} to return an $n \times \tilde{k}$ matrix
 \begin{equation} \label{eq:15}
   \Psi -
-  \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}\Phi
-  \hat{A}_{11}^{-t}\hat{\tilde{A}}_{21}', 
+  \frac{n}{n_{\mathcal{C}}}\Phi
+  \hat{A}_{11}^{-t}\hat{\tilde{A}}_{21}' = \Psi -
+ \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}\Phi
+ \hat{A}_{11}^{-1}\hat{A}_{21}^{\prime},
 \end{equation}
-while continuing to allow \texttt{sandwich::bread()} as applied to
-\texttt{DirectAdjusted} objects to return an (appropriately scaled)
-inverted estimate of $A_{22}$, then the effect of this will be for \texttt{sandwich::sandwich()}
+while \texttt{sandwich::bread()} as applied to
+\texttt{DirectAdjusted} objects returns $\hat{\tilde{A}}_{22}^{-1} = nn_{\mathcal{Q}}^{-1}\hat{A}_{22}^{-1}$, then the effect of this will be for \texttt{sandwich::sandwich()}
 and \texttt{sandwich::vcovCL()} to return \eqref{eq:6} with
 $\hat{M}$'s,  as
 given by \eqref{eq:7} or \eqref{eq:8} respectively, substituted for
@@ -597,8 +598,8 @@ defining $\tilde{k}$ by 1 random matrices
     \psi_\text{DA}(\vec{Z}; \tau, \alpha, 
     \beta) = \psi (\vec{Z}; \tau,\alpha, 
     \beta) -
-    \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}
-    \hat{\tilde{A}}_{21}(\beta) \hat{A}_{11}^{-1}(\beta)\phi(\vec{Z}_{i};
+    \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}
+    \hat{{A}}_{21}(\beta) \hat{A}_{11}^{-1}(\beta)\phi(\vec{Z}_{i};
     \beta), 
 \end{equation}
 we have in the model-based formulation 
@@ -606,9 +607,9 @@ we have in the model-based formulation
   \operatorname{Cov}\left(n^{-1/2}\sum_{i=1}^{n} \psi_\text{DA}(\vec{Z}_{i}; \tau_{(n)},\alpha_{(n)},
     \beta_{(n)})\right) = \\
   M_{22} -
-                                 \frac{n^{1/2}}{n_{\mathcal{C}}^{1/2}}[M_{21}A_{11}^{-t}\tilde{A}_{21}^t
+                                 \frac{n_{\mathcal{Q}}}{(n n_{\mathcal{C}})^{1/2}}[M_{21}A_{11}^{-t}\tilde{A}_{21}^t
                                  + \tilde{A}_{21}A_{11}^{-1}M_{12}] +
-                                 \frac{n}{n_C}\tilde{A}_{21}A_{11}^{-1}M_{11}A_{11}^{-t}\tilde{A}_{21}^{t}, \label{eq:12}
+                                 \frac{n_{\mathcal{Q}}^{2}}{nn_C}{A}_{21}A_{11}^{-1}M_{11}A_{11}^{-t}{A}_{21}^{t}, \label{eq:12}
                                \end{multline}
 regardless of what adjustments for
 clustering or heteroskedasticity that we might seek to apply.
@@ -620,16 +621,16 @@ $\hat{\tilde{A}}_{21}(\beta_{(n)})$ and $\hat{A}_{11}(\beta_{(n)})$ needn't
 coincide with $\tilde{A}_{21}(\beta_{(n)})$ and ${A}_{11}(\beta_{(n)})$, respectively.  In both design- and model-based settings, absorption (e.g. of intercepts) introduces additional wrinkles.
 
 This generalizes readily beyond comparison regressions of the type encoded in \eqref{eq:14}. Should $\tilde{\psi}(\cdot; \cdot)$ encode such a regression with a subgroup or continuous moderator variable, or even with the offset $g(\vec{x}\beta)$ replaced with independent variables $\gamma_{0}g(\vec{x}\beta) + \sum_{j=1}^{k}\gamma_{j} g(\vec{x}\beta)\indicator{a_{i}=j}$, then we only have to generate a corresponding ${A}_{21}(\cdot)$ to use
-\begin{equation*}
+\begin{equation*}\label{eq:24}
       \tilde{\psi}_\text{DA}(\vec{Z}; \tau, \alpha, 
     \beta) = \tilde{\psi} (\vec{Z}; \tau,\alpha, 
     \beta) -
-    \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}
+    \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}
     \hat{\mathrm{A}}_{21}(\beta) \hat{A}_{11}^{-1}(\beta)\phi(\vec{Z}_{i};
     \beta)
 \end{equation*}
-in combination with $\hat{A}_{22}^{-1}$ as bread matrix. As long as the comparison regression value inherits from \texttt{lm} (or \texttt{glm}), \texttt{sandwich::bread()} as applied to it will with little or no modification return
-$\mathrm{A}_{22}^{-1}$; \texttt{sandwich::vcov()} and \texttt{sandwich::vcovCL()} should do the right thing. 
+in combination with $\hat{\tilde{A}}_{22}^{-1}$ as bread matrix. As long as the comparison regression value inherits from \texttt{lm} (or \texttt{glm}), \texttt{sandwich::bread()} as applied to it will with little or no modification return
+$\hat{\mathrm{A}}_{22}^{-1}$, which we can readily rescale to obtain $\hat{\tilde{\mathrm{A}}}_{22}^{-1}$; \texttt{sandwich::vcov()} and \texttt{sandwich::vcovCL()} should do the right thing.
 
 
 \section{Accommodating intercept(s) via absorption}\label{sec:accomm-interc-via}
@@ -778,15 +779,15 @@ basis for variance-covariance estimation.}
   sandwich estimates by substitution of $\acute{\Psi}$ for
 $\Psi$ in \eqref{eq:15}.  That is, for a
 \texttt{DirectAdjusted} object \texttt{DA} we should have
-\begin{equation*}
+\begin{equation*}\label{eq:26}
 \mathtt{estfun.DirectAdjusted(DA)} = 
   \begin{cases}
   \acute{\Psi} -
-  \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}\Phi
+  \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}\Phi
   \hat{A}_{11}^{-t}\hat{A}_{21}'& \mathtt{DA} \text{ absorbs
     intercepts}\\
 \Psi -
-  \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}\Phi
+  \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}\Phi
   \hat{A}_{11}^{-t}\hat{A}_{21}'  & \text{ otherwise}.
 \end{cases}
 \end{equation*}
@@ -818,16 +819,16 @@ $A_{\mathbf{p}, \mathbf{p}} = n^{-1}\sum_{i\in \bigcup
   \mathcal{Q}}\mathbb{E}[\nabla_{\mathbf{p}}\acute{\psi}(\vec{Z}_{i};
 \mathbf{p}, \beta, \tau)]$.  For design-based variance-covariance
 estimation one uses as estimating function
-\begin{multline*}
+\begin{multline*}\label{eq:25}
   \mathtt{estfun.DirectAdjusted(DA)} -
   \mathtt{estfun\_DB\_blockabsorb(DA)} =\\
 \begin{cases}
 \acute{\Psi} -
-  \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}\Phi
+  \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}\Phi
   \hat{A}_{11}^{-t}\hat{A}_{21}'  - \AbsorbInterceptsEF{}
   A_{\mathbf{p}\,\mathbf{p}}^{-1}\hat{A}_{\tau\,\mathbf{p}}' & \mathtt{DA} \text{ absorbs intercepts}\\
  \Psi -
-  \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}\Phi
+  \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}\Phi
   \hat{A}_{11}^{-t}\hat{A}_{21}' 
  & \text{ otherwise}.\\
 \end{cases}
@@ -989,7 +990,7 @@ For design-based calculations, \texttt{estfun\_DB\_blockabsorb(DA)}
  \begin{equation}
    \label{eq:19}
   \acute{\Psi} -
-  \left(\frac{n}{n_{\mathcal{C}}}\right)^{1/2}\Phi
+  \frac{n_{\mathcal{Q}}}{n_{\mathcal{C}}}\Phi
   \hat{A}_{11}^{-t}\hat{A}_{21}' - \AbsorbInterceptsEF{}
   A_{\mathbf{p}\,\mathbf{p}}^{-1}\hat{A}_{\tau\,\mathbf{p}}' -
   \AbsorbModeratorEF{}A_{\gamma \gamma}^{-1}\hat{A}_{\tau \gamma}'


### PR DESCRIPTION
Josh W helpfully pointed out a spec bug.  This PR aims to correct it and some others that came to light in the process of reviewing and confirming that fix.  

The problems were a combination of later parts of the spec doc getting out of sync with earlier parts that had been revised, as well as mistakes regarding scaling factors in $M_{21}$.  A general theme of this update is that expressions along lines of
![image](https://github.com/benbhansen-stats/propertee/assets/827606/6dd7ee23-2f14-4ac2-8bbf-1db970447c7d)
turn into expressions like
![image](https://github.com/benbhansen-stats/propertee/assets/827606/0c857399-c3aa-4321-a65f-188d41fe227a)
