### PR TITLE
#194 .get_a21 when rows in model matrix or prediction gradient are NA

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: propertee
-Version: 0.5.0
+Version: 0.5.1
 Title: Standardization-Based Effect Estimation with Optional Prior Covariance Adjustment
 Description: The Prognostic Regression Offsets with Propagation of
     ERrors (for Treatment Effect Estimation) package facilitates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# propertee 0.5.1
+## Bug Fixes
+* Variance estimation routine fixes miscalculations in the case when there is covariance adjustment and rows are omitted from the `lmitt()` fit due to `NA`'s in the covariates or treatment assignment
+
 # propertee 0.5.0
 
 ## Major Changes

--- a/tests/testthat/test.SandwichLayerVariance.R
+++ b/tests/testthat/test.SandwichLayerVariance.R
@@ -1224,10 +1224,10 @@ test_that(paste(".get_a21 returns correct matrix when data input for lmitt",
   pg <- stats::model.matrix(formula(cmod), m_data)
   nq <- nrow(ssmod_mm)
 
-  a21_as.lmitt <- suppressWarnings(propertee:::.get_a21(m_as.lmitt))
+  a21_as.lmitt <- suppressWarnings(.get_a21(m_as.lmitt))
   expect_true(all.equal(a21_as.lmitt, crossprod(ssmod_mm, pg) / nq,
                         check.attributes = FALSE))
-  a21_lmitt.form <- suppressWarnings(propertee:::.get_a21(m_lmitt.form))
+  a21_lmitt.form <- suppressWarnings(.get_a21(m_lmitt.form))
   expect_true(all.equal(a21_lmitt.form, crossprod(ssmod_mm, pg) / nq,
                         check.attributes = FALSE))
 })
@@ -1238,18 +1238,21 @@ test_that(paste(".get_a21 returns correct matrix when data input for lmitt has
   simdata[simdata$uoa1 %in% c(2, 4), "z"] <- NA_integer_
   cmod <- lm(y ~ x, data = simdata, subset = uoa1 %in% c(2, 4))
   spec <- rct_spec(z ~ cluster(uoa1, uoa2), simdata)
-  m_as.lmitt <- lmitt(lm(y ~ assigned(), simdata, offset = cov_adj(cmod, specification = spec)))
-  m_lmitt.form <- lmitt(y ~ 1, simdata, specification = spec, offset = cov_adj(cmod))
+  m_as.lmitt <- lmitt(
+    lm(y ~ assigned(), simdata, w = ate(spec, data = simdata),
+       offset = cov_adj(cmod, specification = spec)))
+  m_lmitt.form <- lmitt(y ~ 1, simdata, specification = spec, w = ate(spec), offset = cov_adj(cmod))
 
   ssmod_mm <- stats::model.matrix(m_as.lmitt)
+  nonna_wts <- m_as.lmitt$weights
   pg <- stats::model.matrix(formula(cmod), simdata)[!is.na(simdata$z),]
   nq <- nrow(ssmod_mm)
 
-  a21_as.lmitt <- suppressWarnings(propertee:::.get_a21(m_as.lmitt))
-  expect_true(all.equal(a21_as.lmitt, crossprod(ssmod_mm, pg) / nq,
+  a21_as.lmitt <- suppressWarnings(.get_a21(m_as.lmitt))
+  expect_true(all.equal(a21_as.lmitt, crossprod(ssmod_mm * nonna_wts, pg) / nq,
                         check.attributes = FALSE))
-  a21_lmitt.form <- suppressWarnings(propertee:::.get_a21(m_lmitt.form))
-  expect_true(all.equal(a21_lmitt.form, crossprod(ssmod_mm, pg) / nq,
+  a21_lmitt.form <- suppressWarnings(.get_a21(m_lmitt.form))
+  expect_true(all.equal(a21_lmitt.form, crossprod(ssmod_mm * nonna_wts, pg) / nq,
                         check.attributes = FALSE))
 })
 


### PR DESCRIPTION
This PR addresses #194, which caught an oversight in our testing suite. We had tests for `.get_a21()` when there were NA's in the `model.matrix()` for the `teeMod` object or the `prediction_gradient` slot of a `SandwichLayer` passed to its offset, but we hadn't tested it when the `teeMod` object also had weights. This demonstrated that we shouldn't grab the weights from the `weights` element of the model, but instead should change the `na.action` of the model object to `exclude` and should use the `weights()` function that then implements it. I've updated the test `".get_a21 returns correct matrix when data input for lmitt has NA values for some treatment assignments"` in `test.SandwichLayerVariance.R` to test this