### PR TITLE
Add demographic info for michigan_school_pairs

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -106,6 +106,9 @@
 #'
 #' @description Schools matched into pairs or triplets approximating the subset
 #' of participating schools in Pane et al. (2014) from Michigan
+#' @details This dataset contains demographic variables for students in Grade 11. 
+#' These demographic variables are sourced from the Common Core of Data (CCD) 
+#' (U.S. Department of Education).
 #' @references Pane, John F., et al. "Effectiveness of cognitive tutor algebra I at scale."
 #' \emph{Educational Evaluation and Policy Analysis} 36.2 (2014): 127-144.
 #'


### PR DESCRIPTION
This PR corresponds to issue #191 

- I added race and sex as separate variables to `michigan_school_pairs`, but in the form of percentage. If the desired columns should be in total number of students, I'm happy to make this quick change. 
- I didn't include the `TOTFRL` (Total Free and Reduced-Price Lunch Eligible Students) variable because it did not have data specifically for students in G11. 
- Added column definition to `data.R`, but don't think it addresses bullet point 3

