### PR TITLE
edited GV data in data.R

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -131,7 +131,7 @@
 #' @title Cluster-randomized experiment data on voter turnout in cable system markets
 #' 
 #' @description This dataset is a toy example derived from a cluster-randomized 
-#' field experiment that evaluates the effect of Rock the Vote TV advertisements 
+#' field experiment that evaluates the effect of \dQuote{Rock the Vote} TV advertisements 
 #' on voter turnout rate. The original study included 23,869 first-time voters 
 #' across 85 cable television markets in 12 states. These markets were grouped 
 #' into matched sets based on their past voter turnout rates and then randomly 

--- a/R/data.R
+++ b/R/data.R
@@ -128,11 +128,16 @@
 #' @keywords dataset
 "michigan_school_pairs"
 
-#' @title GV data
+#' @title Cluster-randomized experiment data on voter turnout in cable system markets
 #' 
-#' @description This dataset contains a 10% random sample of individuals from each cable system cluster. 
-#' It specifically includes matched pairs 1–3, which correspond to 7 out of the 85 cable systems. 
-#' The original dataset is derived from a cluster-randomized experiment of Rock the Vote TV advertisements.
+#' @description This dataset is a toy example derived from a cluster-randomized 
+#' field experiment that evaluates the effect of Rock the Vote TV advertisements 
+#' on voter turnout rate. The original study included 23,869 first-time voters 
+#' across 85 cable television markets in 12 states. These markets were grouped 
+#' into matched sets based on their past voter turnout rates and then randomly 
+#' assigned to either a treatment or control condition. This toy dataset is 
+#' constructed by randomly sampling 10% of individuals from selected cable 
+#' television markets in the original dataset.
 #'
 #' @format A \code{data.frame} with 248 rows and 7 columns.
 #' \itemize{
@@ -144,12 +149,27 @@
 #'   \item {population_size} Total population size of residential area served by cable system
 #'   \item {sample_size} Number of individuals sampled from the cable system cluster
 #' }
-#' @details The fuller Green-Vavreck dataset that this derives from bears a Creative Commons BY-NC-ND license (v3.0) and is housed in Yale University's Institution for Social and Policy Studies (ID: D005).
+#' 
+#' @details The original dataset was drawn from a randomized controlled trial in 
+#' which 85 cable system areas were first grouped into 40 matched sets based on 
+#' historical voter turnout. Within each matched set, one cable system area was 
+#' randomly assigned to the treatment condition, while the others served 
+#' as controls. 
+#' 
+#' This toy dataset includes a subset of the original replication data, 
+#' specifically individuals from matched sets 1–3, which encompass 7 of the 85 
+#' cable system areas. Within these selected clusters, a 10% random sample of 
+#' individuals was taken.
+#' 
+#' The fuller Green-Vavreck dataset that this derives from bears a Creative 
+#' Commons BY-NC-ND license (v3.0) and is housed in Yale University's Institution 
+#' for Social and Policy Studies (ID: D005).
+#'
+#' @source <https://isps.yale.edu/research/data/d005>
 #'
 #' @references Green, Donald P. & Lynn Vavreck (2008) "Analysis of Cluster-Randomized 
 #' Experiments: A Comparison of Alternative Estimation Approaches." Political Analysis 16(2):138-152.
 #'
-#' @source <https://isps.yale.edu/research/data/d005>
 #' @keywords dataset
 "GV_data"
 

--- a/man/GV_data.Rd
+++ b/man/GV_data.Rd
@@ -3,7 +3,7 @@
 \docType{data}
 \name{GV_data}
 \alias{GV_data}
-\title{GV data}
+\title{Cluster-randomized experiment data on voter turnout in cable system markets}
 \format{
 A \code{data.frame} with 248 rows and 7 columns.
 \itemize{
@@ -23,12 +23,30 @@ A \code{data.frame} with 248 rows and 7 columns.
 GV_data
 }
 \description{
-This dataset contains a 10\% random sample of individuals from each cable system cluster.
-It specifically includes matched pairs 1–3, which correspond to 7 out of the 85 cable systems.
-The original dataset is derived from a cluster-randomized experiment of Rock the Vote TV advertisements.
+This dataset is a toy example derived from a cluster-randomized
+field experiment that evaluates the effect of Rock the Vote TV advertisements
+on voter turnout rate. The original study included 23,869 first-time voters
+across 85 cable television markets in 12 states. These markets were grouped
+into matched sets based on their past voter turnout rates and then randomly
+assigned to either a treatment or control condition. This toy dataset is
+constructed by randomly sampling 10\% of individuals from selected cable
+television markets in the original dataset.
 }
 \details{
-The fuller Green-Vavreck dataset that this derives from bears a Creative Commons BY-NC-ND license (v3.0) and is housed in Yale University's Institution for Social and Policy Studies (ID: D005).
+The original dataset was drawn from a randomized controlled trial in
+which 85 cable system areas were first grouped into 40 matched sets based on
+historical voter turnout. Within each matched set, one cable system area was
+randomly assigned to the treatment condition, while the others served
+as controls.
+
+This toy dataset includes a subset of the original replication data,
+specifically individuals from matched sets 1–3, which encompass 7 of the 85
+cable system areas. Within these selected clusters, a 10\% random sample of
+individuals was taken.
+
+The fuller Green-Vavreck dataset that this derives from bears a Creative
+Commons BY-NC-ND license (v3.0) and is housed in Yale University's Institution
+for Social and Policy Studies (ID: D005).
 }
 \references{
 Green, Donald P. & Lynn Vavreck (2008) "Analysis of Cluster-Randomized

--- a/man/GV_data.Rd
+++ b/man/GV_data.Rd
@@ -24,7 +24,7 @@ GV_data
 }
 \description{
 This dataset is a toy example derived from a cluster-randomized
-field experiment that evaluates the effect of Rock the Vote TV advertisements
+field experiment that evaluates the effect of \dQuote{Rock the Vote} TV advertisements
 on voter turnout rate. The original study included 23,869 first-time voters
 across 85 cable television markets in 12 states. These markets were grouped
 into matched sets based on their past voter turnout rates and then randomly


### PR DESCRIPTION
This PR corresponds to issue #202 that was reopened. Here's a summary of what I did:

- improved `@title` for clarity 
- expanded the `@description` block by stating the overview of the original dataset, mentioning this dataset is a toy example of the original data and how the toy example dataset was sampled
- details on matched pairs and how samples were selected can be found in the `@details` block 
- In addition, `cable system cluster` has been replaced with `cable system markets/areas` for better user familiarity 

