### PR TITLE
error in weights when specification uses dataframe's rownames to identify units of assignment

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: propertee
-Version: 1.0.4.9004
+Version: 1.0.4.9005
 Title: Standardization-Based Effect Estimation with Optional Prior Covariance Adjustment
 Description: The Prognostic Regression Offsets with Propagation of
     ERrors (for Treatment Effect Estimation) package facilitates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# **propertee** 1.0.5 (Unreleased)
+* Fix bug in `ate()/ett()/...` when units of assignment are identified in a `StudySpecification` by the rownames of a dataframe, that is, the `StudySpecification` is created by a call of the form `*_spec(trt ~ 1 + ..., data)`
+
 # **propertee** 1.0.4
 * Fix routines for CR2/CV2 standard errors and associated degrees of freedom that previously errored when the provided `teeMod` had a non-empty `na.action`, or the `teeMod` or its `weights` argument had a `dichotomy` slot
 * Return NaN for the degrees of freedom when CR2/CV2 standard errors have deficient degrees of freedom

--- a/R/weights_internal.R
+++ b/R/weights_internal.R
@@ -139,6 +139,9 @@ NULL
   uoadata$specification_weights <- weights
   
   # Merge with data to expand weights to unit of analysis level
+  if (uoanames == "..uoa..") {
+    data[["..uoa.."]] <- rownames(data)
+  }
   weights <- .merge_preserve_order(data, uoadata,
                                    by = uoanames,
                                    all.x = TRUE)$specification_weights

--- a/R/weights_internal.R
+++ b/R/weights_internal.R
@@ -139,7 +139,7 @@ NULL
   uoadata$specification_weights <- weights
   
   # Merge with data to expand weights to unit of analysis level
-  if (uoanames == "..uoa..") {
+  if (uoanames[1L] == "..uoa.." & length(uoanames) == 1L) {
     data[["..uoa.."]] <- rownames(data)
   }
   weights <- .merge_preserve_order(data, uoadata,

--- a/tests/testthat/test.WeightedStudySpecification.notforCRAN.R
+++ b/tests/testthat/test.WeightedStudySpecification.notforCRAN.R
@@ -776,3 +776,13 @@ test_that("assignment weights persist when data argument excludes some units", {
   expected_wts <- c(rep(2, 10), rep(1, 10), rep(0, 20))
   expect_equal(wts@.Data, expected_wts)
 })
+
+test_that("weights when units of assignment are identified by rownames", {
+  data(simdata)
+  expect_warning(rct_spec <- rct_spec(z ~ 1, simdata), "explicit unit")
+  ettwts <- ett(rct_spec, data = simdata)
+  piZ <- mean(simdata$z)
+  expect_equal(ettwts@.Data, simdata$z + (1 - simdata$z) * piZ / (1 - piZ))
+  atewts <- ate(rct_spec, data = simdata)
+  expect_equal(atewts@.Data, simdata$z / piZ + (1 - simdata$z) / (1 - piZ))
+})


### PR DESCRIPTION
The `ate()/ett()` functions fail when called on a `StudySpecification` object whose formula has a `1` on the righthand side. This is because the `data` argument to the weight-creation function does not have the `..uoa..` column needed to merge to data created from the `StudySpecification` object. This PR addresses that.