### PR TITLE
Moderator estimates df

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: propertee
-Version: 1.0.4.9005
+Version: 1.0.4.9006
 Title: Standardization-Based Effect Estimation with Optional Prior Covariance Adjustment
 Description: The Prognostic Regression Offsets with Propagation of
     ERrors (for Treatment Effect Estimation) package facilitates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # **propertee** 1.0.5 (Unreleased)
+## Updates
+* `vcov_tee()` accepts a new `values_from` argument: users may pass a fitted model object whose residuals and weights will be used for estimating standard errors. This fitted model could be fit under specified parameter restrictions, for example.
+* Model-based standard errors no longer by default cluster at the block level for fine strata (blocks where the treatment or control condition are assigned a lone unit). See further discussion in Wasserman's 2026 thesis "Methods for causal inference in settings with clustered data subject to missingness and measurement error".
+
+## Bug Fixes
 * Fix bug in `ate()/ett()/...` when units of assignment are identified in a `StudySpecification` by the rownames of a dataframe, that is, the `StudySpecification` is created by a call of the form `*_spec(trt ~ 1 + ..., data)`
+* Fix bug that allowed observations with zero weight to figure in degrees of freedom calculations for moderator estimates
 
 # **propertee** 1.0.4
 * Fix routines for CR2/CV2 standard errors and associated degrees of freedom that previously errored when the provided `teeMod` had a non-empty `na.action`, or the `teeMod` or its `weights` argument had a `dichotomy` slot

--- a/R/SandwichLayerVariance.R
+++ b/R/SandwichLayerVariance.R
@@ -672,35 +672,31 @@ cluster_iss <- function(tm,
     stop(paste("Could not find argument passed to `model_data` in the given `envir`"))
   }
   
-  # set these attributes so model.matrix() includes rows with NA's, which will match
-  # the length of `cluster` generated below
-  attr(model_data, "terms") <- NULL
-  attr(model_data, "na.action") <- "na.pass"
+  # this allows us to use napredict below to expand the weights vector
+  if (!is.null(model$na.action)) class(model$na.action) <- "exclude"
 
   # For categorical moderators, count the clusters contributing to estimation
   # for each level of the moderator variable; for continuous moderators, just
   # count the number of clusters. The moderator variable (or any level of the
   # moderator variable) must have at least three clusters contributing to
   # estimation for valid SE estimation.
-  mod_vars <- model.matrix(as.formula(paste0("~-1+", model@moderator)), model_data)
   cluster <- .sanitize_Q_ids(model, cluster_cols)$cluster
+  mod_form <- as.formula(paste0("~-1+", model@moderator))
+  mf <- stats::expand.model.frame(model, mod_form, na.expand = FALSE)
+  mod_vars <- stats::model.matrix(mod_form, mf)
+  if (is.null(wts <- model$weights)) wts <- rep(1, nrow(model$model))
+  in_model_fit <- ifelse(stats::napredict(model$na.action, wts) > 0,
+                         1,
+                         0)
+  in_model_fit[model$na.action] <- 0
   if (ncol(mod_vars) > 1) {
-    # Since model_vars and cluster may include rows with NA's that weren't used
-    # to fit the model, we need to create in_model_fit to determine rows that
-    # were. The approach below uses the row.names in the na.action to indicate
-    # which were not
-    # in_model_fit <- as.numeric(
-    #   apply(mapply(function(c) is.na(c),
-    #                eval(attr(terms(as.formula(model$call$formula)), "variables"), env = model_data)),
-    #         1,
-    #         function(r) sum(r) == 0)
-    # )
-    in_model_fit <- rep(1, length(cluster))
-    in_model_fit[model$na.action] <- 0
     mod_counts <- rowsum(mod_vars * in_model_fit, cluster, na.rm = TRUE)
     valid_mods <- colSums(mod_counts != 0) > 2
   } else {
-    valid_mods <- stats::setNames(length(unique(cluster)) > 2, model@moderator)
+    # for continuous moderators, there are 4 coefficients to estimate. need more
+    # than that for a variance estimate
+    valid_mods <- stats::setNames(length(unique(cluster[in_model_fit == 1])) > 4,
+                                  model@moderator)
   }
 
 

--- a/R/SandwichLayerVariance.R
+++ b/R/SandwichLayerVariance.R
@@ -119,14 +119,16 @@ vcov_tee <- function(x, type = NULL, cluster = NULL, ...) {
 
   # NA any invalid estimates due to degrees of freedom checks
   if (inherits(x, "teeMod")) {
-    vmat <- .check_df_moderator_estimates(vmat, x, args$cluster_cols)
+    if (is.null(values_from <- args$values_from)) values_from <- x
+    vmat <- .check_df_moderator_estimates(vmat, x, args$cluster_cols, values_from)
   } else {
     start_ix <- 0
     for (mod_ix in seq_along(x)) {
       mod <- x[[mod_ix]]
+      if (is.null(values_from <- args$values_from)) values_from <- mod
       vmat_ix <- start_ix + seq_along(mod$coefficients)
       vmat[vmat_ix, vmat_ix] <- .check_df_moderator_estimates(
-        vmat, mod, args$cluster_cols)[vmat_ix, vmat_ix]
+        vmat, mod, args$cluster_cols, values_from)[vmat_ix, vmat_ix]
       start_ix <- start_ix + length(mod$coefficients)
     }
     vmat[apply(is.na(vmat), 1, any),] <- NA_real_
@@ -652,27 +654,36 @@ cluster_iss <- function(tm,
 #' @return A variance-covariance matrix with NA's for estimates lacking
 #'   sufficient degrees of freedom
 #' @keywords internal
-.check_df_moderator_estimates <- function(vmat, model, cluster_cols, model_data = quote(data),
+.check_df_moderator_estimates <- function(vmat,
+                                          model,
+                                          cluster_cols,
+                                          values_from = model,
+                                          model_data = quote(data),
                                           envir = environment(formula(model))) {
   if (!inherits(model, "teeMod")) {
     stop("`model` must be a teeMod object")
   }
 
-  if (length(model@moderator) == 0) {
-    return(vmat)
-  }
+  # if no moderator variable, no need to check df
+  if (length(model@moderator) == 0) return(vmat)
 
+  # if values_from didn't include the moderator, don't check df
+  rhs_values_from <- trimws(
+    strsplit(deparse1(stats::formula(values_from)[[3L]]), "\\+")[[1L]]
+  )
+  if (!any(grepl(model@moderator, rhs_values_from, fixed = TRUE))) return(vmat)
+
+  # get model_data as a dataframe
   if (inherits(model_data, "name")) {
     model_data <- get(as.character(model_data), envir)
   } else if (!inherits(model_data, "data.frame")) {
     stop("`model_data` must be a dataframe or a quoted object name")
   }
-  
   if (!inherits(model_data, "data.frame")) {
-    stop(paste("Could not find argument passed to `model_data` in the given `envir`"))
+    stop("Could not find argument passed to `model_data` in the given `envir`")
   }
   
-  # this allows us to use napredict below to expand the weights vector
+  # set na.action to exclude to use napredict below to expand the weights vector
   if (!is.null(model$na.action)) class(model$na.action) <- "exclude"
 
   # For categorical moderators, count the clusters contributing to estimation
@@ -700,7 +711,7 @@ cluster_iss <- function(tm,
   }
 
 
-  # Replace SE's for moderator variable/levels with <= 2 clusters with NA's
+  # Replace SE's that don't meet df requirements with NA's
   if (any(!valid_mods)) {
     invalid_mods <- gsub("\\)", "\\\\)", gsub("\\(", "\\\\(", names(valid_mods)[!valid_mods]))
     warning(paste("The following subgroups do not have sufficient degrees of",

--- a/R/teeMod.R
+++ b/R/teeMod.R
@@ -321,46 +321,6 @@ bread.teeMod <- function(x, values_from = x, ...)
         paste(sample(letters, 8, replace = TRUE), collapse = ""),
         simplify = TRUE
       )
-      
-      if (inherits(mod, "teeMod")) {
-        uoa_cols <- var_names(mod@StudySpecification, "u")
-        if (has_blocks(mod@StudySpecification)) {
-          if (any(sml_blks <- identify_small_blocks(mod@StudySpecification))) {
-            if (length(setdiff(cluster_cols, uoa_cols)) == 0 &
-                length(setdiff(uoa_cols, cluster_cols)) == 0) {
-              Q_obs <- .sanitize_Q_ids(mod, id_col = cluster_cols)
-              Q_obs_ids <- Q_obs$cluster
-              spec_blocks <- blocks(mod@StudySpecification)
-              uoa_block_ids <- apply(spec_blocks,
-                                     1,
-                                     function(...) paste(..., collapse = ","))
-              structure_w_small_blocks <- cbind(
-                mod@StudySpecification@structure,
-                small_block = sml_blks[uoa_block_ids],
-                block_replace_id = apply(
-                  spec_blocks,
-                  1,
-                  function(nms, ...) paste(paste(nms, ..., sep = ""),
-                                           collapse = ","),
-                  nms = colnames(spec_blocks)
-                )
-              )
-              Q_obs <- .merge_preserve_order(Q_obs,
-                                             structure_w_small_blocks,
-                                             by = uoa_cols,
-                                             all.x = TRUE)
-              na_blocks <- apply(
-                Q_obs[var_names(x@StudySpecification, "b")],
-                1,
-                function(x) any(is.na(x))
-              )
-              Q_obs$cluster[Q_obs$small_block & !na_blocks] <-
-                Q_obs$block_replace_id[Q_obs$small_block & !na_blocks]
-              cls <- Q_obs$cluster
-            }
-          }
-        }
-      }
 
       g <- length(unique(cls))
       n <- nrow(efm)
@@ -753,31 +713,6 @@ bread.teeMod <- function(x, values_from = x, ...)
   # in Q
   Q_obs <- .sanitize_Q_ids(x, id_col = cluster, ...)
   Q_obs_ids <- Q_obs$cluster
-
-  # for model-based vcov calls on blocked specifications when clustering is
-  # called for at the assignment level, replace unit of assignment ID's with
-  # block ID's for small blocks
-  if (vcov_type %in% c("CR", "HC", "MB") & has_blocks(x@StudySpecification)) {
-    uoa_cols <- var_names(x@StudySpecification, "u")
-    if (length(setdiff(cluster, uoa_cols)) == 0 & length(setdiff(uoa_cols, cluster)) == 0) {
-      spec_blocks <- blocks(x@StudySpecification)
-      uoa_block_ids <- apply(spec_blocks, 1,
-                             function(...) paste(..., collapse = ","))
-      small_blocks <- identify_small_blocks(x@StudySpecification)
-      structure_w_small_blocks <- cbind(
-        x@StudySpecification@structure,
-        small_block = small_blocks[uoa_block_ids],
-        block_replace_id = apply(spec_blocks, 1,
-                                 function(nms, ...) paste(paste(nms, ..., sep = ""), collapse = ","),
-                                 nms = colnames(spec_blocks))
-      )
-      Q_obs <- .merge_preserve_order(Q_obs, structure_w_small_blocks, by = uoa_cols, all.x = TRUE)
-      na_blocks <- apply(Q_obs[var_names(x@StudySpecification, "b")], 1, function(x) any(is.na(x)))
-      Q_obs$cluster[Q_obs$small_block & !na_blocks] <-
-        Q_obs$block_replace_id[Q_obs$small_block & !na_blocks]
-      Q_obs_ids <- Q_obs$cluster
-    }
-  }
 
   # If there's no covariance adjustment info, return the ID's found in Q
   if (!inherits(ca <- x$model$`(offset)`, "SandwichLayer")) {

--- a/man/dot-check_df_moderator_estimates.Rd
+++ b/man/dot-check_df_moderator_estimates.Rd
@@ -9,6 +9,7 @@ insufficient degrees of freedom with \code{NA}}
   vmat,
   model,
   cluster_cols,
+  values_from = model,
   model_data = quote(data),
   envir = environment(formula(model))
 )

--- a/tests/testthat/test.SandwichLayerVariance.R
+++ b/tests/testthat/test.SandwichLayerVariance.R
@@ -2862,6 +2862,34 @@ test_that(".check_df_moderator_estimates other warnings", {
                "`model_data` must be a dataframe")
 })
 
+test_that(".check_df_moderator_estimates #246", {
+  # observations that did not contribute to the model fit do not count towards
+  # the degrees of freedom count for moderator estimates
+  set.seed(341)
+  Qdata <- data.frame(x = factor(rep(c(1, 2), each = 3)),
+                      z = rep(c(0, 1), 3),
+                      y = runif(6))
+  wts <- c(0, rep(1, 5))
+  expect_warning(spec <- obs_spec(z ~ 1, Qdata), "explicit unit")
+  tm <- lmitt(y ~ x, spec, Qdata, weights = wts)
+  expect_warning(
+    vc <- vcov_tee(tm),
+    "x1"
+  )
+  expect_true(all(is.na(vc["z._x1",])))
+  expect_true(all(is.na(vc[,"z._x1"])))
+
+  Qdata$x2 <- runif(nrow(Qdata))
+  wts <- rep(c(0, 1), c(2, 4))
+  tm <- lmitt(y ~ x2, spec, Qdata, weights = wts)
+  expect_warning(
+    vc <- vcov_tee(tm),
+    "x2"
+  )
+  expect_true(all(is.na(vc["z._x2",])))
+  expect_true(all(is.na(vc[,"z._x2"])))
+})
+
 test_that("#123 ensure PreSandwich are converted to Sandwich", {
   data(simdata)
   spec <- rct_spec(z ~ uoa(uoa1, uoa2), data = simdata)

--- a/tests/testthat/test.SandwichLayerVariance.R
+++ b/tests/testthat/test.SandwichLayerVariance.R
@@ -508,7 +508,7 @@ test_that("cluster_iss with fine strata (clusters have trt and ctrl units)", {
   wts <- c(rep(2/3, 6), rep(1, 4), rep(4, 2), rep(1, 8))
   tm <- lmitt(yi ~ 1, imb, data = sdata, weights = wts, absorb = TRUE)
   ids <- propertee:::.make_uoa_ids(tm, "MB")
-  ix <- ids == "bi2"
+  ix <- ids == "2"
   A <- model.matrix(tm)
   Ag <- A[ix,,drop=FALSE]
   Pgg <- (Ag * sqrt(wts[ix])) %*% chol2inv(tm$qr$qr) %*% t(Ag * sqrt(wts[ix]))
@@ -2927,7 +2927,8 @@ test_that("#123 ensure PreSandwich are converted to Sandwich", {
 
 })
 
-test_that("model-based SE's cluster units of assignment in small blocks at block level", {
+test_that(paste("model-based SE's cluster units of assignment in small blocks",
+                "at uoa level"), {
   specdata <- data.frame(bid = rep(c(1, 2), each = 20),
                         uoa_id = c(rep(c(1, 2), each = 10), rep(seq(3, 6), each = 5)),
                         a = c(rep(c(0, 1), each = 10), rep(rep(c(0, 1), each = 5), 2)))
@@ -2938,7 +2939,7 @@ test_that("model-based SE's cluster units of assignment in small blocks at block
   vc_w_no_small_block_clusters <- .vcov_CR(mod,
                                            cluster = .make_uoa_ids(mod, "DB"),
                                            by = "uoa_id")
-  expect_true(vc_w_small_block_clusters[2, 2] != vc_w_no_small_block_clusters[2, 2])
+  expect_true(vc_w_small_block_clusters[2, 2] == vc_w_no_small_block_clusters[2, 2])
 })
 
 test_that("#177 vcov with by argument", {

--- a/tests/testthat/test.SandwichLayerVariance.R
+++ b/tests/testthat/test.SandwichLayerVariance.R
@@ -2856,9 +2856,11 @@ test_that(".check_df_moderator_estimates other warnings", {
   # invalid `data` arg
   spec <- rct_spec(z ~ cluster(uoa1, uoa2), simdata)
   ssmod <- lmitt(y ~ factor(o), specification = spec, data = simdata)
-  expect_error(.check_df_moderator_estimates(vmat, ssmod, cluster_ids,
-                                             cbind(y = simdata$y, z = simdata$z),
-                                             envir = parent.frame()),
+  expect_error(.check_df_moderator_estimates(vmat, ssmod
+                                             , cluster_cols = c("uoa1", "uoa2")
+                                             , model_data = cbind(y = simdata$y,
+                                                                  z = simdata$z)
+                                             , envir = parent.frame()),
                "`model_data` must be a dataframe")
 })
 
@@ -2888,6 +2890,11 @@ test_that(".check_df_moderator_estimates #246", {
   )
   expect_true(all(is.na(vc["z._x2",])))
   expect_true(all(is.na(vc[,"z._x2"])))
+  
+  # if values_from is fit w/o the moderator, don't check df
+  values_from <- lmitt(y ~ 1, spec, Qdata, weights = wts)
+  vc <- vcov_tee(tm, values_from = values_from)
+  expect_true(all(is.na(vc)))
 })
 
 test_that("#123 ensure PreSandwich are converted to Sandwich", {

--- a/tests/testthat/test.teeMod.R
+++ b/tests/testthat/test.teeMod.R
@@ -1236,17 +1236,16 @@ test_that("rcorrect (HC/CR/MB)2, clustering", {
   pm <- chol2inv(next_xm$qr$qr)
   X <- stats::model.matrix(next_xm)
   expected <- numeric(nrow(sdat))
-  for (c in unique(sdat$b)) {
-    ix <- sdat$b == c
+  for (ix in seq_len(nrow(sdat))) {
     Xc <- X[ix,,drop=FALSE]
-    Pc <- Xc %*% pm %*% t(Xc) %*% diag(next_xm$weights[ix], nrow = sum(ix))
-    schur <- eigen(diag(nrow = sum(ix)) - Pc)
-    crc <- schur$vector %*% diag(1/sqrt(schur$values),
-                          nrow = sum(ix)) %*% solve(schur$vector) %*% r[ix]
+    Pc <- Xc %*% pm %*% t(Xc) %*% diag(next_xm$weights[ix], nrow = length(ix))
+    schur <- eigen(diag(nrow = length(ix)) - Pc)
+    crc <- schur$vector %*% diag(1/sqrt(schur$values), nrow = length(ix)) %*% 
+      solve(schur$vector) %*% r[ix]
     expected[ix] <- crc
   }
   expect_equal(
-    cr <- .rcorrect(r, x = next_xm, model = "itt", type = "HC2"),
+    cr <- unname(.rcorrect(r, x = next_xm, model = "itt", type = "HC2")),
     expected
   )
 })
@@ -2020,28 +2019,25 @@ test_that(".make_uoa_ids without `by` when Q and C ID's aren't unique", {
                "not uniquely specified. Provide a `by` argument")
 })
 
-test_that(paste("unit-level clustering model-based .make_uoa_ids uses block",
-                "ID's for small blocks"), {
+test_that(paste("unit-level clustering model-based .make_uoa_ids does not use",
+                "block ID's for small blocks"), {
   data(simdata)
 
   spec <- rct_spec(z ~ cluster(uoa1, uoa2) + block(bid), simdata)
   suppressMessages(dmod <- lmitt(y ~ 1, specification = spec, data = simdata))
 
+  uoa_ids <- factor(apply(simdata[, c("uoa1", "uoa2")],
+                          1,
+                          function(...) paste(..., collapse = "_")))
   expect_equal(
     out <- .make_uoa_ids(dmod, "CR"),
-    factor(paste0("bid",
-                  c(rep("1", sum(simdata$bid == 1)),
-                    rep("2", sum(simdata$bid == 2)),
-                    rep("3", sum(simdata$bid == 3)))),
-                  levels = paste0("bid", c("1", "2", "3")))
+    uoa_ids
   )
   expect_equal(out, .make_uoa_ids(dmod, "MB"))
   expect_equal(out, .make_uoa_ids(dmod, "HC"))
   expect_equal(
     .make_uoa_ids(dmod, "DB"),
-    factor(apply(simdata[, c("uoa1", "uoa2")],
-                 1,
-                 function(...) paste(..., collapse = "_")))
+    out
   )
 })
 


### PR DESCRIPTION
These commits address issue #246 .

Commit de1aa3f makes a more general change than what's noted in issue #246: it reverts clustering model-based vcov estimates at the block level in settings with small blocks to clustering at the unit level. This reflects conclusions we've reached in offline discussions.