### PR TITLE
BUG logic for applying .check_df_moderator_estimates to mmm objects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: propertee
-Version: 1.0.5.9001
+Version: 1.0.5.9002
 Title: Standardization-Based Effect Estimation with Optional Prior Covariance Adjustment
 Description: The Prognostic Regression Offsets with Propagation of
     ERrors (for Treatment Effect Estimation) package facilitates

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# **propertee** 1.0.6 (Unreleased)
+## Bug Fixes
+* `vcov_tee()` does not error when some fitted models in an object created by `mmm()` have coefficients estimated as NA
+
 # **propertee** 1.0.5
 ## Updates
 * `vcov_tee()` accepts a new `values_from` argument: users may pass a fitted model object whose residuals and weights will be used for estimating standard errors. This fitted model could be fit under specified parameter restrictions, for example.

--- a/R/SandwichLayerVariance.R
+++ b/R/SandwichLayerVariance.R
@@ -126,10 +126,11 @@ vcov_tee <- function(x, type = NULL, cluster = NULL, ...) {
     for (mod_ix in seq_along(x)) {
       mod <- x[[mod_ix]]
       if (is.null(values_from <- args$values_from)) values_from <- mod
-      vmat_ix <- start_ix + seq_along(mod$coefficients)
+      not_aliased <- !is.na(mod$coefficients)
+      vmat_ix <- start_ix + seq_len(sum(not_aliased))
       vmat[vmat_ix, vmat_ix] <- .check_df_moderator_estimates(
         vmat, mod, args$cluster_cols, values_from)[vmat_ix, vmat_ix]
-      start_ix <- start_ix + length(mod$coefficients)
+      start_ix <- start_ix + sum(not_aliased)
     }
     vmat[apply(is.na(vmat), 1, any),] <- NA_real_
     vmat[,apply(is.na(vmat), 2, any)] <- NA_real_

--- a/tests/testthat/test.SandwichLayerVariance.R
+++ b/tests/testthat/test.SandwichLayerVariance.R
@@ -2897,6 +2897,22 @@ test_that(".check_df_moderator_estimates #246", {
   expect_true(all(is.na(vc)))
 })
 
+if (requireNamespace("multcomp", quietly = TRUE)) {
+  test_that(".check_df_moderator_estimates w/ mmm object and aliased coeffs", {
+    set.seed(4953)
+    dft <- data.frame(y = rnorm(20),
+                      z = rep(c(0,1), each = 10),
+                      x1 = factor(rep(letters[1:3], 7)[seq_len(20)]))
+    dft$x2 <- dft$z
+    expect_warning(dta <- rct_spec(z ~ 1, dft), "explicit unit")
+    tm1 <- lmitt(y ~ 1, dta, dft)
+    tm2 <- lmitt(y ~ x1, dta, dft)
+    tm3 <- lmitt(y ~ x2, dta, dft)
+    mco <- multcomp::mmm(main = tm1, x1 = tm2, x2 = tm3)
+    expect_silent(invisible(vcov_tee(mco)))
+  })
+}
+
 test_that("#123 ensure PreSandwich are converted to Sandwich", {
   data(simdata)
   spec <- rct_spec(z ~ uoa(uoa1, uoa2), data = simdata)


### PR DESCRIPTION
`.check_df_moderator_estimates` was causing issues in ee_statistical component when applied to an object created by `mmm()` because it assumed NA coefficients would be in the output of `.vcov_*`. commit 4958230 fixes this